### PR TITLE
Fix Tailwind configuration load order

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Realm of Legends Companion</title>
   <!-- Tailwind CSS CDN with dark mode enabled via class strategy -->
+  <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
       darkMode: 'class',
@@ -15,7 +16,6 @@
       plugins: [],
     }
   </script>
-  <script src="https://cdn.tailwindcss.com" defer></script>
   <style>
     html {
       scroll-behavior: smooth;


### PR DESCRIPTION
## Summary
- move custom `tailwind.config` below the CDN script to avoid a ReferenceError

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844493629288322aa97655398a263d9