### PR TITLE
Fix guides image loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
         <div class="space-y-12">
           <article class="flex flex-col md:flex-row items-center bg-gray-50 dark:bg-gray-800 rounded-lg shadow-md p-6">
             <img
-              src="https://via.placeholder.com/200"
+              src="data:image/svg+xml,<svg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%27200%27%20height=%27200%27><rect%20width=%27100%%27%20height=%27100%%27%20fill=%27%23ccc%27/><text%20x=%2750%%27%20y=%2750%%27%20dominant-baseline=%27middle%27%20text-anchor=%27middle%27%20font-size=%2720%27%20fill=%27%23666%27>Image</text></svg>"
               alt="Class Guide"
               class="w-full md:w-48 h-32 object-cover rounded-md mb-4 md:mb-0 md:mr-6"
             />
@@ -171,7 +171,7 @@
           </article>
           <article class="flex flex-col md:flex-row items-center bg-gray-50 dark:bg-gray-800 rounded-lg shadow-md p-6">
             <img
-              src="https://via.placeholder.com/200"
+              src="data:image/svg+xml,<svg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%27200%27%20height=%27200%27><rect%20width=%27100%%27%20height=%27100%%27%20fill=%27%23ccc%27/><text%20x=%2750%%27%20y=%2750%%27%20dominant-baseline=%27middle%27%20text-anchor=%27middle%27%20font-size=%2720%27%20fill=%27%23666%27>Image</text></svg>"
               alt="Raid Strategies"
               class="w-full md:w-48 h-32 object-cover rounded-md mb-4 md:mb-0 md:mr-6"
             />
@@ -185,7 +185,7 @@
           </article>
           <article class="flex flex-col md:flex-row items-center bg-gray-50 dark:bg-gray-800 rounded-lg shadow-md p-6">
             <img
-              src="https://via.placeholder.com/200"
+              src="data:image/svg+xml,<svg%20xmlns=%27http://www.w3.org/2000/svg%27%20width=%27200%27%20height=%27200%27><rect%20width=%27100%%27%20height=%27100%%27%20fill=%27%23ccc%27/><text%20x=%2750%%27%20y=%2750%%27%20dominant-baseline=%27middle%27%20text-anchor=%27middle%27%20font-size=%2720%27%20fill=%27%23666%27>Image</text></svg>"
               alt="Economy Tips"
               class="w-full md:w-48 h-32 object-cover rounded-md mb-4 md:mb-0 md:mr-6"
             />


### PR DESCRIPTION
## Summary
- replace external placeholder URLs with inline SVG images so that guides images load correctly

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68444ab1ba488322967be25c9d97d9d2